### PR TITLE
Fix: Reload inspector to show correct properties after running plugin

### DIFF
--- a/NudgitShapes.sketchplugin/Contents/Sketch/nearest-height.cocoascript
+++ b/NudgitShapes.sketchplugin/Contents/Sketch/nearest-height.cocoascript
@@ -18,12 +18,13 @@ var onRun = function (context) {
     log("true");
     height = height + 8;
     } else {
-    log("false"); 
+    log("false");
     height = Math.ceil(height/8.0) * 8;
     }
 
-    
+
   [[layer frame] setHeight: (height)]
   [doc showMessage: "Height: " + height];
   log(height);
+  context.document.reloadInspector()
 }

--- a/NudgitShapes.sketchplugin/Contents/Sketch/nearest-width.cocoascript
+++ b/NudgitShapes.sketchplugin/Contents/Sketch/nearest-width.cocoascript
@@ -18,12 +18,13 @@ var onRun = function (context) {
     log("true");
     width = width + 8;
     } else {
-    log("false"); 
+    log("false");
     width = Math.ceil(width/8.0) * 8;
     }
 
-    
+
   [[layer frame] setWidth: (width)]
   [doc showMessage: "Width: " + width];
   log(width);
+  context.document.reloadInspector()
 }


### PR DESCRIPTION
Width / height was not updated in the Sketch UI after running plugin.